### PR TITLE
fix: S3バックエンドのtfstateキーを修正

### DIFF
--- a/terraform/aws/img.cube-unit.net/main.tf
+++ b/terraform/aws/img.cube-unit.net/main.tf
@@ -10,7 +10,7 @@ terraform {
   backend "s3" {
     bucket  = "terraform.cube-unit.net"
     region  = "ap-northeast-1"
-    key     = "cube-unit.net/aws/%%TARGET%%/terraform.tfstate"
+    key     = "cube-unit.net/aws/img.cube-unit.net/terraform.tfstate"
     encrypt = true
   }
 

--- a/terraform/aws/static.cube-unit.net/main.tf
+++ b/terraform/aws/static.cube-unit.net/main.tf
@@ -10,7 +10,7 @@ terraform {
   backend "s3" {
     bucket  = "terraform.cube-unit.net"
     region  = "ap-northeast-1"
-    key     = "cube-unit.net/aws/%%TARGET%%/terraform.tfstate"
+    key     = "cube-unit.net/aws/static.cube-unit.net/terraform.tfstate"
     encrypt = true
   }
 


### PR DESCRIPTION
- img.cube-unit.net/main.tf: tfstateキーを"cube-unit.net/aws/img.cube-unit.net/terraform.tfstate"に更新
- static.cube-unit.net/main.tf: tfstateキーを"cube-unit.net/aws/static.cube-unit.net/terraform.tfstate"に更新