### PR TITLE
feat: CloudFrontディストリビューションにS3バケットへの依存関係を追加

### DIFF
--- a/terraform/aws/cube-unit.net/cloudfront.tf
+++ b/terraform/aws/cube-unit.net/cloudfront.tf
@@ -1,5 +1,9 @@
 
 resource "aws_cloudfront_distribution" "s3_distribution" {
+  depends_on = [
+    aws_s3_bucket.main,
+  ]
+
   aliases                         = [
     local.domain
   ]

--- a/terraform/aws/img.cube-unit.net/cloudfront.tf
+++ b/terraform/aws/img.cube-unit.net/cloudfront.tf
@@ -1,4 +1,8 @@
 resource "aws_cloudfront_distribution" "s3_distribution" {
+  depends_on = [
+    aws_s3_bucket.main,
+  ]
+
   aliases                         = [
     local.domain
   ]

--- a/terraform/aws/static.cube-unit.net/cloudfront.tf
+++ b/terraform/aws/static.cube-unit.net/cloudfront.tf
@@ -1,5 +1,9 @@
 
 resource "aws_cloudfront_distribution" "s3_distribution" {
+  depends_on = [
+    aws_s3_bucket.main,
+  ]
+
   aliases                         = [
     local.domain
   ]

--- a/terraform/aws/stg.cube-unit.net/cloudfront.tf
+++ b/terraform/aws/stg.cube-unit.net/cloudfront.tf
@@ -1,5 +1,9 @@
 
 resource "aws_cloudfront_distribution" "s3_distribution" {
+  depends_on = [
+    aws_s3_bucket.main,
+  ]
+
   aliases                         = [
     local.domain
   ]


### PR DESCRIPTION
- terraform/aws/cube-unit.net/cloudfront.tf
- terraform/aws/img.cube-unit.net/cloudfront.tf
- terraform/aws/static.cube-unit.net/cloudfront.tf
- terraform/aws/stg.cube-unit.net/cloudfront.tf

各CloudFrontディストリビューションリソースに対して、aws_s3_bucket.mainへの依存関係を追加しました。