### PR TITLE
fix: locals.tfのドメイン定義のスペースを修正

### DIFF
--- a/terraform/aws/cube-unit.net/locals.tf
+++ b/terraform/aws/cube-unit.net/locals.tf
@@ -2,5 +2,5 @@ locals {
   account_id = data.aws_caller_identity.current.account_id
   region = "ap-northeast-1"
 
-  domain="cube-unit.net"
+  domain = "cube-unit.net"
 }

--- a/terraform/aws/img.cube-unit.net/locals.tf
+++ b/terraform/aws/img.cube-unit.net/locals.tf
@@ -2,5 +2,5 @@ locals {
   account_id = data.aws_caller_identity.current.account_id
   region = "ap-northeast-1"
 
-  domain="img.cube-unit.net"
+  domain = "img.cube-unit.net"
 }

--- a/terraform/aws/static.cube-unit.net/locals.tf
+++ b/terraform/aws/static.cube-unit.net/locals.tf
@@ -2,5 +2,5 @@ locals {
   account_id = data.aws_caller_identity.current.account_id
   region = "ap-northeast-1"
 
-  domain="static.cube-unit.net"
+  domain = "static.cube-unit.net"
 }

--- a/terraform/aws/stg.cube-unit.net/locals.tf
+++ b/terraform/aws/stg.cube-unit.net/locals.tf
@@ -2,5 +2,5 @@ locals {
   account_id = data.aws_caller_identity.current.account_id
   region = "ap-northeast-1"
 
-  domain="stg.cube-unit.net"
+  domain = "stg.cube-unit.net"
 }


### PR DESCRIPTION
- terraform/aws/cube-unit.net/locals.tf: ドメイン定義にスペースを追加
- terraform/aws/img.cube-unit.net/locals.tf: ドメイン定義にスペースを追加
- terraform/aws/static.cube-unit.net/locals.tf: ドメイン定義にスペースを追加
- terraform/aws/stg.cube-unit.net/locals.tf: ドメイン定義にスペースを追加