### PR TITLE
fix: aliasesのフォーマットを修正

### DIFF
--- a/terraform/aws/cube-unit.net/cloudfront.tf
+++ b/terraform/aws/cube-unit.net/cloudfront.tf
@@ -4,7 +4,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     aws_s3_bucket.main,
   ]
 
-  aliases                         = [
+  aliases = [
     local.domain
   ]
 


### PR DESCRIPTION
cloudfront.tfのaliasesの定義において、スペースを削除しました。