### PR TITLE
fix: S3バケットのリージョンを東京に変更

### DIFF
--- a/terraform/aws/cube-unit.net/cloudfront.tf
+++ b/terraform/aws/cube-unit.net/cloudfront.tf
@@ -35,7 +35,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     realtime_log_config_arn    = null
     response_headers_policy_id = null
     smooth_streaming           = false
-    target_origin_id           = "${local.domain}.s3.amazonaws.com"
+    target_origin_id           = "${local.domain}.s3-ap-northeast-1.amazonaws.com"
     trusted_key_groups         = []
     trusted_signers            = []
     viewer_protocol_policy     = "allow-all"
@@ -53,9 +53,9 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   origin {
     connection_attempts      = 3
     connection_timeout       = 10
-    domain_name              = "${local.domain}.s3.amazonaws.com"
+    domain_name              = "${local.domain}.s3-ap-northeast-1.amazonaws.com"
     origin_access_control_id = aws_cloudfront_origin_access_control.s3_distribution.id
-    origin_id                = "${local.domain}.s3.amazonaws.com"
+    origin_id                = "${local.domain}.s3-ap-northeast-1.amazonaws.com"
     origin_path              = null
   }
 
@@ -77,7 +77,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 
 resource "aws_cloudfront_origin_access_control" "s3_distribution" {
   description                       = null
-  name                              = "${local.domain}.s3.amazonaws.com"
+  name                              = "${local.domain}.s3-ap-northeast-1.amazonaws.com"
   origin_access_control_origin_type = "s3"
   signing_behavior                  = "always"
   signing_protocol                  = "sigv4"

--- a/terraform/aws/img.cube-unit.net/cloudfront.tf
+++ b/terraform/aws/img.cube-unit.net/cloudfront.tf
@@ -34,7 +34,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     realtime_log_config_arn    = null
     response_headers_policy_id = null
     smooth_streaming           = false
-    target_origin_id           = "${local.domain}.s3.amazonaws.com"
+    target_origin_id           = "${local.domain}.s3-ap-northeast-1.amazonaws.com"
     trusted_key_groups         = []
     trusted_signers            = []
     viewer_protocol_policy     = "allow-all"
@@ -52,9 +52,9 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   origin {
     connection_attempts      = 3
     connection_timeout       = 10
-    domain_name              = "${local.domain}.s3.amazonaws.com"
+    domain_name              = "${local.domain}.s3-ap-northeast-1.amazonaws.com"
     origin_access_control_id = aws_cloudfront_origin_access_control.s3_distribution.id
-    origin_id                = "${local.domain}.s3.amazonaws.com"
+    origin_id                = "${local.domain}.s3-ap-northeast-1.amazonaws.com"
     origin_path              = null
   }
 
@@ -76,7 +76,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 
 resource "aws_cloudfront_origin_access_control" "s3_distribution" {
   description                       = null
-  name                              = "${local.domain}.s3.amazonaws.com"
+  name                              = "${local.domain}.s3-ap-northeast-1.amazonaws.com"
   origin_access_control_origin_type = "s3"
   signing_behavior                  = "always"
   signing_protocol                  = "sigv4"

--- a/terraform/aws/static.cube-unit.net/cloudfront.tf
+++ b/terraform/aws/static.cube-unit.net/cloudfront.tf
@@ -35,7 +35,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     realtime_log_config_arn    = null
     response_headers_policy_id = null
     smooth_streaming           = false
-    target_origin_id           = "${local.domain}.s3.amazonaws.com"
+    target_origin_id           = "${local.domain}.s3-ap-northeast-1.amazonaws.com"
     trusted_key_groups         = []
     trusted_signers            = []
     viewer_protocol_policy     = "allow-all"
@@ -53,9 +53,9 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   origin {
     connection_attempts      = 3
     connection_timeout       = 10
-    domain_name              = "${local.domain}.s3.amazonaws.com"
+    domain_name              = "${local.domain}.s3-ap-northeast-1.amazonaws.com"
     origin_access_control_id = aws_cloudfront_origin_access_control.s3_distribution.id
-    origin_id                = "${local.domain}.s3.amazonaws.com"
+    origin_id                = "${local.domain}.s3-ap-northeast-1.amazonaws.com"
     origin_path              = null
   }
 
@@ -77,7 +77,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 
 resource "aws_cloudfront_origin_access_control" "s3_distribution" {
   description                       = null
-  name                              = "${local.domain}.s3.amazonaws.com"
+  name                              = "${local.domain}.s3-ap-northeast-1.amazonaws.com"
   origin_access_control_origin_type = "s3"
   signing_behavior                  = "always"
   signing_protocol                  = "sigv4"

--- a/terraform/aws/stg.cube-unit.net/cloudfront.tf
+++ b/terraform/aws/stg.cube-unit.net/cloudfront.tf
@@ -35,7 +35,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     realtime_log_config_arn    = null
     response_headers_policy_id = null
     smooth_streaming           = false
-    target_origin_id           = "${local.domain}.s3.amazonaws.com"
+    target_origin_id           = "${local.domain}.s3-ap-northeast-1.amazonaws.com"
     trusted_key_groups         = []
     trusted_signers            = []
     viewer_protocol_policy     = "allow-all"
@@ -53,9 +53,9 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   origin {
     connection_attempts      = 3
     connection_timeout       = 10
-    domain_name              = "${local.domain}.s3.amazonaws.com"
+    domain_name              = "${local.domain}.s3-ap-northeast-1.amazonaws.com"
     origin_access_control_id = aws_cloudfront_origin_access_control.s3_distribution.id
-    origin_id                = "${local.domain}.s3.amazonaws.com"
+    origin_id                = "${local.domain}.s3-ap-northeast-1.amazonaws.com"
     origin_path              = null
   }
 
@@ -77,7 +77,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 
 resource "aws_cloudfront_origin_access_control" "s3_distribution" {
   description                       = null
-  name                              = "${local.domain}.s3.amazonaws.com"
+  name                              = "${local.domain}.s3-ap-northeast-1.amazonaws.com"
   origin_access_control_origin_type = "s3"
   signing_behavior                  = "always"
   signing_protocol                  = "sigv4"


### PR DESCRIPTION
- cloudfront.tf (各環境):
  - target_origin_id, domain_name, origin_id, nameを「.s3.amazonaws.com」から「.s3-ap-northeast-1.amazonaws.com」に変更