### PR TITLE
feat: CloudFrontのURLリライト機能とカスタムエラーページを追加

### DIFF
--- a/terraform/aws/cube-unit.net/cloudfront-function.tf
+++ b/terraform/aws/cube-unit.net/cloudfront-function.tf
@@ -1,0 +1,7 @@
+resource "aws_cloudfront_function" "url_rewrite" {
+  name    = "${local.domain}-url-rewrite"
+  runtime = "cloudfront-js-1.0"
+  comment = "URL rewrite function for cube-unit.net Hugo static site"
+  publish = true
+  code    = file("${path.module}/functions/url-rewrite.js")
+}

--- a/terraform/aws/cube-unit.net/cloudfront.tf
+++ b/terraform/aws/cube-unit.net/cloudfront.tf
@@ -40,9 +40,27 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     trusted_signers            = []
     viewer_protocol_policy     = "redirect-to-https"
 
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.url_rewrite.arn
+    }
+
     grpc_config {
       enabled = false
     }
+  }
+
+  # カスタムエラーページ設定
+  custom_error_response {
+    error_code         = 403
+    response_code      = 404
+    response_page_path = "/404.html"
+  }
+
+  custom_error_response {
+    error_code         = 404
+    response_code      = 404
+    response_page_path = "/404.html"
   }
 
   origin {

--- a/terraform/aws/cube-unit.net/functions/url-rewrite.js
+++ b/terraform/aws/cube-unit.net/functions/url-rewrite.js
@@ -1,0 +1,27 @@
+function handler(event) {
+    var request = event.request;
+    var uri = request.uri;
+
+    // ルートパスはそのまま（default_root_objectでindex.htmlが配信される）
+    if (uri === '/') {
+        return request;
+    }
+
+    // 既に拡張子がある場合はそのまま
+    if (uri.includes('.')) {
+        return request;
+    }
+
+    // 末尾にスラッシュがない場合、スラッシュとindex.htmlを追加
+    // /about → /about/index.html
+    if (!uri.endsWith('/')) {
+        request.uri = uri + '/index.html';
+    }
+    // 末尾がスラッシュの場合、index.htmlを追加
+    // /about/ → /about/index.html
+    else {
+        request.uri = uri + 'index.html';
+    }
+
+    return request;
+}

--- a/terraform/aws/stg.cube-unit.net/cloudfront-function.tf
+++ b/terraform/aws/stg.cube-unit.net/cloudfront-function.tf
@@ -1,0 +1,7 @@
+resource "aws_cloudfront_function" "url_rewrite" {
+  name    = "${local.domain}-url-rewrite"
+  runtime = "cloudfront-js-1.0"
+  comment = "URL rewrite function for cube-unit.net Hugo static site"
+  publish = true
+  code    = file("${path.module}/functions/url-rewrite.js")
+}

--- a/terraform/aws/stg.cube-unit.net/cloudfront.tf
+++ b/terraform/aws/stg.cube-unit.net/cloudfront.tf
@@ -40,9 +40,27 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     trusted_signers            = []
     viewer_protocol_policy     = "redirect-to-https"
 
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.url_rewrite.arn
+    }
+
     grpc_config {
       enabled = false
     }
+  }
+
+  # カスタムエラーページ設定
+  custom_error_response {
+    error_code         = 403
+    response_code      = 404
+    response_page_path = "/404.html"
+  }
+
+  custom_error_response {
+    error_code         = 404
+    response_code      = 404
+    response_page_path = "/404.html"
   }
 
   origin {

--- a/terraform/aws/stg.cube-unit.net/functions/url-rewrite.js
+++ b/terraform/aws/stg.cube-unit.net/functions/url-rewrite.js
@@ -1,0 +1,27 @@
+function handler(event) {
+    var request = event.request;
+    var uri = request.uri;
+
+    // ルートパスはそのまま（default_root_objectでindex.htmlが配信される）
+    if (uri === '/') {
+        return request;
+    }
+
+    // 既に拡張子がある場合はそのまま
+    if (uri.includes('.')) {
+        return request;
+    }
+
+    // 末尾にスラッシュがない場合、スラッシュとindex.htmlを追加
+    // /about → /about/index.html
+    if (!uri.endsWith('/')) {
+        request.uri = uri + '/index.html';
+    }
+    // 末尾がスラッシュの場合、index.htmlを追加
+    // /about/ → /about/index.html
+    else {
+        request.uri = uri + 'index.html';
+    }
+
+    return request;
+}


### PR DESCRIPTION
- cloudfront.tf: viewer-requestイベントに対する関数を追加し、403および404エラーに対するカスタムエラーページを設定
- cloudfront-function.tf: URLリライト用のCloudFront関数を新規作成
- url-rewrite.js: リクエストURIを処理するURLリライトロジックを実装