### PR TITLE
fix: URLリライト機能のドメイン名のフォーマットを修正

### DIFF
--- a/terraform/aws/cube-unit.net/cloudfront-function.tf
+++ b/terraform/aws/cube-unit.net/cloudfront-function.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudfront_function" "url_rewrite" {
-  name    = "${local.domain}-url-rewrite"
+  name    = "${replace(local.domain, ".", "-")}-url-rewrite"
   runtime = "cloudfront-js-1.0"
   comment = "URL rewrite function for cube-unit.net Hugo static site"
   publish = true

--- a/terraform/aws/stg.cube-unit.net/cloudfront-function.tf
+++ b/terraform/aws/stg.cube-unit.net/cloudfront-function.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudfront_function" "url_rewrite" {
-  name    = "${local.domain}-url-rewrite"
+  name    = "${replace(local.domain, ".", "-")}-url-rewrite"
   runtime = "cloudfront-js-1.0"
   comment = "URL rewrite function for cube-unit.net Hugo static site"
   publish = true


### PR DESCRIPTION
- cloudfront-function.tfのname属性を修正し、ドメイン名のピリオドをハイフンに置き換えるように変更しました。