### PR TITLE
feat: CloudFrontのアセットリダイレクト機能を追加

### DIFF
--- a/terraform/aws/cube-unit.net/cloudfront-function.tf
+++ b/terraform/aws/cube-unit.net/cloudfront-function.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudfront_function" "url_rewrite" {
   name    = "${replace(local.domain, ".", "-")}-url-rewrite"
-  runtime = "cloudfront-js-1.0"
-  comment = "URL rewrite function for cube-unit.net Hugo static site"
+  runtime = "cloudfront-js-2.0"
+  comment = "URL rewrite function for ${local.domain} Hugo static site"
   publish = true
   code    = file("${path.module}/functions/url-rewrite.js")
 }

--- a/terraform/aws/cube-unit.net/cloudfront.tf
+++ b/terraform/aws/cube-unit.net/cloudfront.tf
@@ -1,9 +1,5 @@
 
 resource "aws_cloudfront_distribution" "s3_distribution" {
-  depends_on = [
-    aws_s3_bucket.main,
-  ]
-
   aliases = [
     local.domain
   ]

--- a/terraform/aws/cube-unit.net/s3.tf
+++ b/terraform/aws/cube-unit.net/s3.tf
@@ -14,7 +14,8 @@ resource "aws_s3_bucket_public_access_block" "main" {
 
 resource "aws_s3_bucket_policy" "policy" {
   depends_on = [
-    aws_s3_bucket.main,
+    aws_s3_bucket_public_access_block.main,
+    aws_cloudfront_distribution.s3_distribution
   ]
   bucket = aws_s3_bucket.main.id
   policy = data.aws_iam_policy_document.policy_document.json

--- a/terraform/aws/img.cube-unit.net/cloudfront-function.tf
+++ b/terraform/aws/img.cube-unit.net/cloudfront-function.tf
@@ -1,0 +1,7 @@
+resource "aws_cloudfront_function" "asset_redirect" {
+  name    = "${replace(local.domain, ".", "-")}-asset-redirect"
+  runtime = "cloudfront-js-2.0"
+  comment = "Asset domain redirect function for ${local.domain}"
+  publish = true
+  code    = file("${path.module}/functions/url-redirect.js")
+}

--- a/terraform/aws/img.cube-unit.net/cloudfront.tf
+++ b/terraform/aws/img.cube-unit.net/cloudfront.tf
@@ -1,8 +1,4 @@
 resource "aws_cloudfront_distribution" "s3_distribution" {
-  depends_on = [
-    aws_s3_bucket.main,
-  ]
-
   aliases                         = [
     local.domain
   ]
@@ -41,12 +37,27 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 
     function_association {
       event_type   = "viewer-request"
-      function_arn = "arn:aws:cloudfront::${local.account_id}:function/cloudfront-s3-redirect"
+      function_arn = aws_cloudfront_function.asset_redirect.arn
     }
 
     grpc_config {
       enabled = false
     }
+  }
+
+  # カスタムエラーページ設定
+  custom_error_response {
+    error_code            = 403
+    response_code         = 301
+    response_page_path    = "/redirect-to-404"
+    error_caching_min_ttl = 0
+  }
+
+  custom_error_response {
+    error_code            = 404
+    response_code         = 301
+    response_page_path    = "/redirect-to-404"
+    error_caching_min_ttl = 0
   }
 
   origin {

--- a/terraform/aws/img.cube-unit.net/functions/url-redirect.js
+++ b/terraform/aws/img.cube-unit.net/functions/url-redirect.js
@@ -1,0 +1,30 @@
+function handler(event) {
+    var request = event.request;
+    var uri = request.uri;
+
+    // ルートページにアクセスした場合はメインサイトにリダイレクト
+    if (uri === '/' || uri === '/index.html') {
+        return {
+            statusCode: 301,
+            statusDescription: 'Moved Permanently',
+            headers: {
+                'location': { value: 'https://cube-unit.net/' }
+            }
+        };
+    }
+
+    // 404リダイレクト用の特別なパス
+    if (uri === '/redirect-to-404') {
+        return {
+            statusCode: 301,
+            statusDescription: 'Moved Permanently',
+            headers: {
+                'location': { value: 'https://cube-unit.net/404.html' }
+            }
+        };
+    }
+
+    // その他のリクエストは全てS3に転送
+    // ファイルが存在する場合は正常配信、存在しない場合はカスタムエラーページが処理
+    return request;
+}

--- a/terraform/aws/img.cube-unit.net/s3.tf
+++ b/terraform/aws/img.cube-unit.net/s3.tf
@@ -14,7 +14,8 @@ resource "aws_s3_bucket_public_access_block" "main" {
 
 resource "aws_s3_bucket_policy" "policy" {
   depends_on = [
-    aws_s3_bucket.main,
+    aws_s3_bucket_public_access_block.main,
+    aws_cloudfront_distribution.s3_distribution
   ]
   bucket = aws_s3_bucket.main.id
   policy = data.aws_iam_policy_document.policy_document.json

--- a/terraform/aws/static.cube-unit.net/cloudfront-function.tf
+++ b/terraform/aws/static.cube-unit.net/cloudfront-function.tf
@@ -1,0 +1,7 @@
+resource "aws_cloudfront_function" "asset_redirect" {
+  name    = "${replace(local.domain, ".", "-")}-asset-redirect"
+  runtime = "cloudfront-js-2.0"
+  comment = "Asset domain redirect function for ${local.domain}"
+  publish = true
+  code    = file("${path.module}/functions/url-redirect.js")
+}

--- a/terraform/aws/static.cube-unit.net/cloudfront.tf
+++ b/terraform/aws/static.cube-unit.net/cloudfront.tf
@@ -1,9 +1,5 @@
 
 resource "aws_cloudfront_distribution" "s3_distribution" {
-  depends_on = [
-    aws_s3_bucket.main,
-  ]
-
   aliases                         = [
     local.domain
   ]
@@ -48,6 +44,21 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     grpc_config {
       enabled = false
     }
+  }
+
+  # カスタムエラーページ設定
+  custom_error_response {
+    error_code            = 403
+    response_code         = 301
+    response_page_path    = "/redirect-to-404"
+    error_caching_min_ttl = 0
+  }
+
+  custom_error_response {
+    error_code            = 404
+    response_code         = 301
+    response_page_path    = "/redirect-to-404"
+    error_caching_min_ttl = 0
   }
 
   origin {

--- a/terraform/aws/static.cube-unit.net/functions/url-redirect.js
+++ b/terraform/aws/static.cube-unit.net/functions/url-redirect.js
@@ -1,0 +1,30 @@
+function handler(event) {
+    var request = event.request;
+    var uri = request.uri;
+
+    // ルートページにアクセスした場合はメインサイトにリダイレクト
+    if (uri === '/' || uri === '/index.html') {
+        return {
+            statusCode: 301,
+            statusDescription: 'Moved Permanently',
+            headers: {
+                'location': { value: 'https://cube-unit.net/' }
+            }
+        };
+    }
+
+    // 404リダイレクト用の特別なパス
+    if (uri === '/redirect-to-404') {
+        return {
+            statusCode: 301,
+            statusDescription: 'Moved Permanently',
+            headers: {
+                'location': { value: 'https://cube-unit.net/404.html' }
+            }
+        };
+    }
+
+    // その他のリクエストは全てS3に転送
+    // ファイルが存在する場合は正常配信、存在しない場合はカスタムエラーページが処理
+    return request;
+}

--- a/terraform/aws/static.cube-unit.net/s3.tf
+++ b/terraform/aws/static.cube-unit.net/s3.tf
@@ -14,7 +14,8 @@ resource "aws_s3_bucket_public_access_block" "main" {
 
 resource "aws_s3_bucket_policy" "policy" {
   depends_on = [
-    aws_s3_bucket.main,
+    aws_s3_bucket_public_access_block.main,
+    aws_cloudfront_distribution.s3_distribution
   ]
   bucket = aws_s3_bucket.main.id
   policy = data.aws_iam_policy_document.policy_document.json

--- a/terraform/aws/stg.cube-unit.net/cloudfront-function.tf
+++ b/terraform/aws/stg.cube-unit.net/cloudfront-function.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudfront_function" "url_rewrite" {
   name    = "${replace(local.domain, ".", "-")}-url-rewrite"
-  runtime = "cloudfront-js-1.0"
-  comment = "URL rewrite function for cube-unit.net Hugo static site"
+  runtime = "cloudfront-js-2.0"
+  comment = "URL rewrite function for ${local.domain} Hugo static site"
   publish = true
   code    = file("${path.module}/functions/url-rewrite.js")
 }

--- a/terraform/aws/stg.cube-unit.net/cloudfront.tf
+++ b/terraform/aws/stg.cube-unit.net/cloudfront.tf
@@ -1,9 +1,5 @@
 
 resource "aws_cloudfront_distribution" "s3_distribution" {
-  depends_on = [
-    aws_s3_bucket.main,
-  ]
-
   aliases                         = [
     local.domain
   ]

--- a/terraform/aws/stg.cube-unit.net/s3.tf
+++ b/terraform/aws/stg.cube-unit.net/s3.tf
@@ -14,7 +14,8 @@ resource "aws_s3_bucket_public_access_block" "main" {
 
 resource "aws_s3_bucket_policy" "policy" {
   depends_on = [
-    aws_s3_bucket.main,
+    aws_s3_bucket_public_access_block.main,
+    aws_cloudfront_distribution.s3_distribution
   ]
   bucket = aws_s3_bucket.main.id
   policy = data.aws_iam_policy_document.policy_document.json


### PR DESCRIPTION
- cloudfront-function.tf: 新しいアセットリダイレクト関数を追加し、runtimeを2.0に更新
- url-redirect.js: アセットリダイレクトのロジックを実装
- cloudfront.tf: 依存関係の修正
- s3.tf: S3バケットポリシーの依存関係を更新