### PR TITLE
refactor: ワークフローの順番待ちの制御方法を変更

### DIFF
--- a/.github/workflows/terraform-deploy.yaml
+++ b/.github/workflows/terraform-deploy.yaml
@@ -10,8 +10,8 @@ on:
       - tfaction-root.yaml
 
 concurrency:
-  group: ${{ github.workflow }}-terraform-${{ github.ref }}
-  cancel-in-progress: false # 本番環境は WF の順番待ちを許可する
+  group: terraform-deploy # デプロイ先が1つしかないため repo 内で排他制御
+  cancel-in-progress: true
 
 env:
   TFACTION_IS_APPLY: "true"

--- a/.github/workflows/terraform-deploy.yaml
+++ b/.github/workflows/terraform-deploy.yaml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-terraform-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false # 本番環境は WF の順番待ちを許可する
 
 env:
   TFACTION_IS_APPLY: "true"

--- a/.github/workflows/terraform-pull-request.yaml
+++ b/.github/workflows/terraform-pull-request.yaml
@@ -10,8 +10,8 @@ on:
       - tfaction-root.yaml
 
 concurrency:
-  group: ${{ github.workflow }}-terraform-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-terraform-${{ github.ref }}  # デプロイしないため PR レベルの排他制御
+  cancel-in-progress: true # PR の更新があった場合は前のジョブをキャンセルする
 
 permissions:
   id-token: write

--- a/.github/workflows/web-deploy-production.yaml
+++ b/.github/workflows/web-deploy-production.yaml
@@ -9,8 +9,8 @@ on:
       - web/**
 
 concurrency:
-  group: ${{ github.workflow }}-web-${{ github.ref }}
-  cancel-in-progress: false # 本番環境は WF の順番待ちを許可する
+  group: web-production # デプロイ先が1つしかないため repo 内で排他制御
+  cancel-in-progress: true
 
 jobs:
   deploy-production:

--- a/.github/workflows/web-deploy-production.yaml
+++ b/.github/workflows/web-deploy-production.yaml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-web-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false # 本番環境は WF の順番待ちを許可する
 
 jobs:
   deploy-production:

--- a/.github/workflows/web-deploy-staging.yaml
+++ b/.github/workflows/web-deploy-staging.yaml
@@ -9,7 +9,7 @@ on:
       - web/**
 
 concurrency:
-  group: ${{ github.workflow }}-web-${{ github.ref }}
+  group: web-staging # デプロイ先が1つしかないため repo 内で排他制御
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
- terraform-deploy.yaml と web-deploy-production.yaml の両方で、concurrencyのcancel-in-progressをtrueからfalseに変更し、本番環境でのワークフローの順番待ちを許可しました。