### PR TITLE
fix: スマートフォン版でのページ上部へ戻るボタンの表示と動作を無効化

### DIFF
--- a/web/themes/cube-unit/static/css/style_sp.css
+++ b/web/themes/cube-unit/static/css/style_sp.css
@@ -489,7 +489,7 @@ hr{
 #footer_menu li a:hover { color:#999; text-decoration:none; }
 
 /* return top */
-#return_top { position:fixed; bottom:0; right:0; display:block; text-indent:100%; overflow:hidden; white-space:nowrap; width:50px; height:50px; margin:0; padding:0; background:#bbb url(img/footer/return_top.png) no-repeat center center; z-index: 999; }
+#return_top { position:fixed; bottom:0; right:0; display:none; text-indent:100%; overflow:hidden; white-space:nowrap; width:50px; height:50px; margin:0; padding:0; background:#bbb url(img/footer/return_top.png) no-repeat center center; z-index: 999; }
 #return_top:hover { background-color:#00a2d9; }
 
 /* social link */

--- a/web/themes/cube-unit/static/js/jscript.js
+++ b/web/themes/cube-unit/static/js/jscript.js
@@ -91,8 +91,13 @@ $(window).bind("resize orientationchange", function() {
   mediaQueryClass(document.documentElement.clientWidth);
 })
 
-// ページ上部へ戻るボタンのアニメーション
+// ページ上部へ戻るボタンのアニメーション（PC版のみ）
 $(window).scroll(function() {
+  // スマートフォン版では処理しない
+  if ($("html").hasClass("mobile")) {
+    return;
+  }
+
   if ($(this).scrollTop() > 100) {
     $('#return_top').fadeIn();
   } else {
@@ -100,8 +105,13 @@ $(window).scroll(function() {
   }
 });
 
-// ページ上部へ戻るボタンのスムーススクロール
+// ページ上部へ戻るボタンのスムーススクロール（PC版のみ）
 $('#return_top').click(function() {
+  // スマートフォン版では処理しない
+  if ($("html").hasClass("mobile")) {
+    return false;
+  }
+
   $('body,html').animate({
     scrollTop: 0
   }, 800);


### PR DESCRIPTION
style_sp.css:
- #return_topのdisplayプロパティをblockからnoneに変更

jscript.js:
- スクロールイベントとクリックイベントで、スマートフォン版の場合は処理をスキップする条件を追加