### PR TITLE
chore: GitHub ActionsにMarkdownのドキュメントチェックを追加

### DIFF
--- a/.github/workflows/web-deploy-staging.yaml
+++ b/.github/workflows/web-deploy-staging.yaml
@@ -13,7 +13,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-documentation:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - id: app-token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e #2.0.6
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
+        with:
+          node-version: '20'
+
+      - name: Install markdownlint
+        run: npm install -g markdownlint-cli2
+
+      - name: Lint Markdown Files
+        run: github-comment exec -k check-markdown -var env:Staging -- markdownlint-cli2 "**/*.md" --config ".markdownlint.json"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Check links in Markdown
+        uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31 #v1.10.17
+        with:
+          use-quiet-mode: 'yes'
+
   deploy-staging:
+    needs: check-documentation
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/web-deploy-staging.yaml
+++ b/.github/workflows/web-deploy-staging.yaml
@@ -47,11 +47,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
-      - name: Check links in Markdown
-        uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31 #v1.10.17
-        with:
-          use-quiet-mode: 'yes'
-
   deploy-staging:
     needs: check-documentation
     permissions:

--- a/.github/workflows/web-deploy-staging.yaml
+++ b/.github/workflows/web-deploy-staging.yaml
@@ -20,11 +20,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - uses: aquaproj/aqua-installer@d1fe50798dbadd4eb5b98957290ca175f6b4870f # v4.0.2
+        with:
+          aqua_version: v2.53.7
+
       - id: app-token
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e #2.0.6
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - run: github-comment exec -- github-comment hide
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
@@ -63,10 +71,6 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
-
-      - run: github-comment exec -- github-comment hide
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f #v3.0.0

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,16 @@
+{
+  "MD013": false,
+  "MD024": false,
+  "MD022": false,
+  "MD032": false,
+  "MD031": false,
+  "MD041": false,
+  "MD029": false,
+  "MD036": false,
+  "MD009": {
+    "br_spaces": 2
+  },
+  "MD046": {
+    "style": "fenced"
+  }
+}

--- a/github-comment.yaml
+++ b/github-comment.yaml
@@ -1,33 +1,35 @@
 vars:
   env: Staging
+templates:
+  base: |
+    {{template "link" .}}
+
+    {{template "join_command" .}}
+
+    {{template "hidden_combined_output" .}}
 exec:
+  check-markdown:
+    - when: ExitCode != 0
+      template: |
+        ## {{template "status" .}} Check Markdown Failed ({{.Vars.env}})
+
+        {{template "base" .}}
+
   build-hugo:
     - when: ExitCode != 0
       template: |
         ## {{template "status" .}} Build Failed ({{.Vars.env}})
 
-        {{template "link" .}}
-
-        {{template "join_command" .}}
-
-        {{template "hidden_combined_output" .}}
+        {{template "base" .}}
 
   deploy-to-s3:
     - when: ExitCode == 0
       template: |
         ## {{template "status" .}} Deploy Succeeded ({{.Vars.env}})
 
-        {{template "link" .}}
-
-        {{template "join_command" .}}
-
-        {{template "hidden_combined_output" .}}
+        {{template "base" .}}
     - when: ExitCode != 0
       template: |
         ## {{template "status" .}} Deploy Failed ({{.Vars.env}})
 
-        {{template "link" .}}
-
-        {{template "join_command" .}}
-
-        {{template "hidden_combined_output" .}}
+        {{template "base" .}}

--- a/web/content/links.md
+++ b/web/content/links.md
@@ -3,7 +3,7 @@ title: "LINKS"
 description: "原作者や同人サークルへのリンク集"
 ---
 
-# 原作者
+## 原作者
 
 **上海アリス幻樂団** – ZUN様
 [![上海アリス幻樂団](http://www16.big.or.jp/~zun/image/banner.gif)](http://www16.big.or.jp/~zun/)

--- a/web/content/links.md
+++ b/web/content/links.md
@@ -3,7 +3,7 @@ title: "LINKS"
 description: "原作者や同人サークルへのリンク集"
 ---
 
-## 原作者
+# 原作者
 
 **上海アリス幻樂団** – ZUN様
 [![上海アリス幻樂団](http://www16.big.or.jp/~zun/image/banner.gif)](http://www16.big.or.jp/~zun/)


### PR DESCRIPTION
- web-deploy-staging.yamlにドキュメントチェックのジョブを追加し、Node.jsとmarkdownlintをセットアップしました。
- markdownlintの設定ファイル(.markdownlint.json)を新規作成しました。
- github-comment.yamlのテンプレートを修正し、Markdownチェックの失敗時のメッセージを更新しました。