### PR TITLE
chore: エラーメッセージのテンプレートを共通化

### DIFF
--- a/.github/workflows/web-deploy-production.yaml
+++ b/.github/workflows/web-deploy-production.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build
         working-directory: web
-        run: github-comment exec -k build-hugo -var env:Production -- hugo --minify
+        run: github-comment exec -k common-error -var env:Production -var title:"Build Failed" -- hugo --minify
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/web-deploy-staging.yaml
+++ b/.github/workflows/web-deploy-staging.yaml
@@ -43,7 +43,7 @@ jobs:
         run: npm install -g markdownlint-cli2
 
       - name: Lint Markdown Files
-        run: github-comment exec -k check-markdown -var env:Staging -- markdownlint-cli2 "**/*.md" --config ".markdownlint.json"
+        run: github-comment exec -k common-error -var env:Staging -var title:"Check Markdown Failed" -- markdownlint-cli2 "**/*.md" --config ".markdownlint.json"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
@@ -74,7 +74,7 @@ jobs:
 
       - name: Build
         working-directory: web
-        run: github-comment exec -k build-hugo -var env:Staging -- hugo
+        run: github-comment exec -k common-error -var env:Staging -var title:"Build Failed" -- hugo
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 

--- a/github-comment.yaml
+++ b/github-comment.yaml
@@ -1,5 +1,6 @@
 vars:
   env: Staging
+  title: Example
 templates:
   base: |
     {{template "link" .}}
@@ -8,17 +9,10 @@ templates:
 
     {{template "hidden_combined_output" .}}
 exec:
-  check-markdown:
+  common-error:
     - when: ExitCode != 0
       template: |
-        ## {{template "status" .}} Check Markdown Failed ({{.Vars.env}})
-
-        {{template "base" .}}
-
-  build-hugo:
-    - when: ExitCode != 0
-      template: |
-        ## {{template "status" .}} Build Failed ({{.Vars.env}})
+        ## {{template "status" .}} {{.Vars.title}} ({{.Vars.env}})
 
         {{template "base" .}}
 


### PR DESCRIPTION
.github/workflows/web-deploy-production.yaml:
- ビルド失敗時のエラーメッセージを共通テンプレートに変更

.github/workflows/web-deploy-staging.yaml:
- Markdownファイルのチェック失敗時のエラーメッセージを共通テンプレートに変更
- ビルド失敗時のエラーメッセージを共通テンプレートに変更

github-comment.yaml:
- エラーメッセージの共通テンプレートを追加し、個別のテンプレートを削除