### PR TITLE
chore: GitHub Actionsのアクションバージョンを更新

### DIFF
--- a/.github/workflows/terraform-deploy.yaml
+++ b/.github/workflows/terraform-deploy.yaml
@@ -66,7 +66,7 @@ jobs:
           aqua_version: v2.53.8
 
       - id: app-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e #2.0.6
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/terraform-pull-request.yaml
+++ b/.github/workflows/terraform-pull-request.yaml
@@ -33,7 +33,7 @@ jobs:
           aqua_version: v2.53.8
 
       - id: app-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e #2.0.6
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
@@ -70,7 +70,7 @@ jobs:
           aqua_version: v2.53.8
 
       - id: app-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e #2.0.6
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/web-deploy-production.yaml
+++ b/.github/workflows/web-deploy-production.yaml
@@ -29,13 +29,13 @@ jobs:
           aqua_version: v2.53.8
 
       - id: app-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e #2.0.6
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f #v3.0.0
+        uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3.0.0
         with:
           hugo-version: '0.123.7'
 
@@ -45,7 +45,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
-      - uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df #v4.2.1
+      - uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
           role-to-assume: arn:aws:iam::158677943024:role/github_cube-unit.net_web_deploy_production
           aws-region: ap-northeast-1

--- a/.github/workflows/web-deploy-staging.yaml
+++ b/.github/workflows/web-deploy-staging.yaml
@@ -25,7 +25,7 @@ jobs:
           aqua_version: v2.53.7
 
       - id: app-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e #2.0.6
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
@@ -35,7 +35,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
 
@@ -62,13 +62,13 @@ jobs:
           aqua_version: v2.53.8
 
       - id: app-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e #2.0.6
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f #v3.0.0
+        uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3.0.0
         with:
           hugo-version: '0.123.7'
 
@@ -78,7 +78,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
-      - uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df #v4.2.1
+      - uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
           role-to-assume: arn:aws:iam::158677943024:role/github_cube-unit.net_web_deploy_staging
           aws-region: ap-northeast-1


### PR DESCRIPTION
- terraform-deploy.yaml: actions/create-github-app-tokenのバージョンをv2.0.6に更新
- terraform-pull-request.yaml: actions/create-github-app-tokenのバージョンをv2.0.6に更新
- web-deploy-production.yaml: actions/create-github-app-tokenのバージョンをv2.0.6に更新、peaceiris/actions-hugoのバージョンをv3.0.0に更新、aws-actions/configure-aws-credentialsのバージョンをv4.2.1に更新
- web-deploy-staging.yaml: actions/create-github-app-tokenのバージョンをv2.0.6に更新、peaceiris/actions-hugoのバージョンをv3.0.0に更新、aws-actions/configure-aws-credentialsのバージョンをv4.2.1に更新