### PR TITLE
feat: pull-request-otherワークフローにドキュメントチェック機能を追加

### DIFF
--- a/.github/workflows/pull-request-other.yaml
+++ b/.github/workflows/pull-request-other.yaml
@@ -16,7 +16,43 @@ concurrency:
   cancel-in-progress: true # PR の更新があった場合は前のジョブをキャンセルする
 
 jobs:
+  check-documentation:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: aquaproj/aqua-installer@d1fe50798dbadd4eb5b98957290ca175f6b4870f # v4.0.2
+        with:
+          aqua_version: v2.53.8
+
+      - id: app-token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - run: github-comment exec -- github-comment hide
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+
+      - name: Install markdownlint
+        run: npm install -g markdownlint-cli2
+
+      - name: Lint Markdown Files
+        run: github-comment exec -k common-error -var env:Staging -var title:"Check Markdown Failed" -- markdownlint-cli2 "**/*.md" --config ".markdownlint.json"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
   success:
+    needs: check-documentation
+    if: ${{ !failure() }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
- pull-request-other.yamlにドキュメントチェック用のジョブを追加しました。
- Markdownファイルのリンティングを行うために、markdownlint-cli2をインストールし、実行するステップを追加しました。
- GitHubアプリのトークンを生成するステップを追加しました。