### PR TITLE
refactor: 不要なCloudflareのDNSインポート設定を削除

### DIFF
--- a/terraform/cloudflare/micmnis.net/page-rules/import.tf
+++ b/terraform/cloudflare/micmnis.net/page-rules/import.tf
@@ -1,9 +1,0 @@
-import {
-  id = "785e8c4ddd38cf2e4058ce71f63310ad/7f3d5948c9a63e1b8f246a72d00f0a33"
-  to = cloudflare_page_rule.root_domain
-}
-
-import {
-  id = "785e8c4ddd38cf2e4058ce71f63310ad/868c05f5783d6bca8bc1333c3315dbda"
-  to = cloudflare_page_rule.sub_domain
-}


### PR DESCRIPTION
terraform/cloudflare/micmnis.net/page-rules/import.tfを削除しました。これにより、不要なインポート設定が整理され、コードベースがクリーンになります。