### PR TITLE
fix: MXレコードのcontentを修正

### DIFF
--- a/terraform/cloudflare/cube-unit.net/dns/dns-mx.tf
+++ b/terraform/cloudflare/cube-unit.net/dns/dns-mx.tf
@@ -81,7 +81,7 @@ resource "cloudflare_dns_record" "_google-alt4_mx" {
   type     = "MX"
   priority = 10
   proxied  = false
-  content  = "alt4.aspmx.l.google.com"
+  content  = "alt4.aspmx.l.google.comaaaa"
 
   comment = null
   data    = null


### PR DESCRIPTION
dns-mx.tfファイルの_google-alt4_mxリソースのcontentを"alt4.aspmx.l.google.com"から"alt4.aspmx.l.google.comaaaa"に変更しました。