### PR TITLE
feat: robots.txtとsitemap.xmlを追加

### DIFF
--- a/web/hugo.toml
+++ b/web/hugo.toml
@@ -3,6 +3,9 @@ languageCode = 'ja'
 title = 'Cube-Unit'
 theme = 'cube-unit'
 
+# Enable robots.txt generation
+enableRobotsTXT = true
+
 # Google Analytics (Google Tag Manager ID or GA4 Measurement ID)
 googleAnalytics = 'G-QGTYH7SE5W'  # Replace with actual GA4 measurement ID
 

--- a/web/layouts/robots.txt
+++ b/web/layouts/robots.txt
@@ -1,0 +1,37 @@
+User-agent: *
+Allow: /
+Disallow: /categories/
+Disallow: /tags/
+
+{{ with .Site.BaseURL }}
+Sitemap: {{ . }}sitemap.xml
+{{ end }}
+
+# Allow common search engines
+User-agent: Googlebot
+Allow: /
+Disallow: /categories/
+Disallow: /tags/
+
+User-agent: Bingbot
+Allow: /
+Disallow: /categories/
+Disallow: /tags/
+
+User-agent: YandexBot
+Allow: /
+Disallow: /categories/
+Disallow: /tags/
+
+# Block SEO crawlers and bots that don't respect crawl-delay
+User-agent: AhrefsBot
+Disallow: /
+
+User-agent: SemrushBot
+Disallow: /
+
+User-agent: MJ12bot
+Disallow: /
+
+User-agent: DotBot
+Disallow: /

--- a/web/layouts/sitemap.xml
+++ b/web/layouts/sitemap.xml
@@ -1,0 +1,13 @@
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{ range .Data.Pages }}
+  {{ if or (or (in .Permalink "/categories/") (in .Permalink "/tags/")) }}
+  {{ else }}
+  <url>
+    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}
+  </url>
+  {{ end }}
+  {{ end }}
+</urlset>


### PR DESCRIPTION
- robots.txtを新規作成し、検索エンジンのクローラーに対するアクセス制御を設定
- sitemap.xmlを新規作成し、サイトのページ構造を検索エンジンに提供