### PR TITLE
Remove_import_and_add_comment

### DIFF
--- a/terraform/cloudflare/cube-unit.net/page-rules/import.tf
+++ b/terraform/cloudflare/cube-unit.net/page-rules/import.tf
@@ -1,4 +1,0 @@
-import {
-  id = "4cf6092c08d51bb2492987f7afff6db3/88eb913ae2c64a4bde1c09cbd15835f3"
-  to = cloudflare_page_rule.magu_otu
-}

--- a/tfaction-root.yaml
+++ b/tfaction-root.yaml
@@ -70,12 +70,12 @@ target_groups:
       aws_assume_role_arn: arn:aws:iam::158677943024:role/github_cube-unit.net_terraform_plan
       secrets:
         - env_name: CLOUDFLARE_API_TOKEN
-          secret_name: CLOUDFLARE_READ_ONLY_API_TOKEN
+          secret_name: CLOUDFLARE_READ_ONLY_API_TOKEN # Account Scope API Token は利用できないため、User Scope API Token が必要
     terraform_apply_config:
       aws_assume_role_arn: arn:aws:iam::158677943024:role/github_cube-unit.net_terraform_apply
       secrets:
         - env_name: CLOUDFLARE_API_TOKEN
-          secret_name: CLOUDFLARE_WRITABLE_API_TOKEN
+          secret_name: CLOUDFLARE_WRITABLE_API_TOKEN # Account Scope API Token は利用できないため、User Scope API Token が必要
 
   - working_directory: terraform/cloudflare/cube-unit.net/zero-trust
     target: terraform/cloudflare/cube-unit.net/zero-trust
@@ -130,12 +130,12 @@ target_groups:
       aws_assume_role_arn: arn:aws:iam::158677943024:role/github_cube-unit.net_terraform_plan
       secrets:
         - env_name: CLOUDFLARE_API_TOKEN
-          secret_name: CLOUDFLARE_READ_ONLY_API_TOKEN
+          secret_name: CLOUDFLARE_READ_ONLY_API_TOKEN # Account Scope API Token は利用できないため、User Scope API Token が必要
     terraform_apply_config:
       aws_assume_role_arn: arn:aws:iam::158677943024:role/github_cube-unit.net_terraform_apply
       secrets:
         - env_name: CLOUDFLARE_API_TOKEN
-          secret_name: CLOUDFLARE_WRITABLE_API_TOKEN
+          secret_name: CLOUDFLARE_WRITABLE_API_TOKEN # Account Scope API Token は利用できないため、User Scope API Token が必要
 
   - working_directory: terraform/cloudflare/micmnis.net/zone
     target: terraform/cloudflare/micmnis.net/zone


### PR DESCRIPTION
tfaction-root.yamlのCLOUDFLARE_API_TOKENに関するコメントを更新し、Account Scope API Tokenが利用できないためUser Scope API Tokenが必要であることを明記しました。