### PR TITLE
fix: タスク名の大文字化

### DIFF
--- a/.github/workflows/wc-terraform-pull-request.yaml
+++ b/.github/workflows/wc-terraform-pull-request.yaml
@@ -136,7 +136,7 @@ jobs:
           action: test
           github_token: ${{ steps.app-token.outputs.token }}
 
-      - name: plan
+      - name: Plan
         uses: suzuki-shunsuke/tfaction@5d2ecf0f4898a0b3ecc6b536e9a3f4691f46bfad # v2.0.0
         with:
           action: plan


### PR DESCRIPTION
wc-terraform-pull-request.yamlのplanタスク名を「Plan」に変更しました。