### PR TITLE
feat: GitHub Secretsをtfactionで出力するステップを追加

### DIFF
--- a/.github/workflows/schedule-detect-drifts.yaml
+++ b/.github/workflows/schedule-detect-drifts.yaml
@@ -93,10 +93,18 @@ jobs:
           role-session-name: ${{ steps.setup.outputs.aws_role_session_name }}
           aws-region: ${{ steps.setup.outputs.aws_region }}
 
+      - name: GitHub Secrets
+        uses: suzuki-shunsuke/tfaction@5d2ecf0f4898a0b3ecc6b536e9a3f4691f46bfad # v2.0.0
+        id: github-secrets
+        with:
+          action: output-github-secrets
+          github_secrets: ${{ toJSON(secrets) }}
+
       - name: Terraform Init
         uses: suzuki-shunsuke/tfaction@5d2ecf0f4898a0b3ecc6b536e9a3f4691f46bfad # v2.0.0
         with:
           action: terraform-init
+          github_secrets: ${{ steps.github-secrets.outputs.secrets }}
 
       - name: Test
         uses: suzuki-shunsuke/tfaction@5d2ecf0f4898a0b3ecc6b536e9a3f4691f46bfad # v2.0.0
@@ -109,6 +117,7 @@ jobs:
         with:
           action: plan
           github_token: ${{ steps.app-token.outputs.token }}
+          github_secrets: ${{ steps.github-secrets.outputs.secrets }}
 
       - name: Update Drift Issue
         uses: suzuki-shunsuke/tfaction@5d2ecf0f4898a0b3ecc6b536e9a3f4691f46bfad # v2.0.0

--- a/.github/workflows/terraform-deploy.yaml
+++ b/.github/workflows/terraform-deploy.yaml
@@ -108,16 +108,25 @@ jobs:
           role-session-name: ${{ steps.setup.outputs.aws_role_session_name }}
           aws-region: ${{ steps.setup.outputs.aws_region }}
 
+      - name: GitHub Secrets
+        uses: suzuki-shunsuke/tfaction@5d2ecf0f4898a0b3ecc6b536e9a3f4691f46bfad # v2.0.0
+        id: github-secrets
+        with:
+          action: output-github-secrets
+          github_secrets: ${{ toJSON(secrets) }}
+
       - name: Terraform Init
         uses: suzuki-shunsuke/tfaction@5d2ecf0f4898a0b3ecc6b536e9a3f4691f46bfad # v2.0.0
         with:
           action: terraform-init
+          github_secrets: ${{ steps.github-secrets.outputs.secrets }}
 
       - name: Apply
         uses: suzuki-shunsuke/tfaction@5d2ecf0f4898a0b3ecc6b536e9a3f4691f46bfad # v2.0.0
         with:
           action: apply
           github_token: ${{ steps.app-token.outputs.token }}
+          github_secrets: ${{ steps.github-secrets.outputs.secrets }}
 
       # Add this after apply
       - name: Update PR Branch

--- a/.github/workflows/wc-terraform-pull-request.yaml
+++ b/.github/workflows/wc-terraform-pull-request.yaml
@@ -125,10 +125,18 @@ jobs:
           role-session-name: ${{ steps.setup.outputs.aws_role_session_name }}
           aws-region: ${{ steps.setup.outputs.aws_region }}
 
+      - name: GitHub Secrets
+        uses: suzuki-shunsuke/tfaction@5d2ecf0f4898a0b3ecc6b536e9a3f4691f46bfad # v2.0.0
+        id: github-secrets
+        with:
+          action: output-github-secrets
+          github_secrets: ${{ toJSON(secrets) }}
+
       - name: Terraform Init
         uses: suzuki-shunsuke/tfaction@5d2ecf0f4898a0b3ecc6b536e9a3f4691f46bfad # v2.0.0
         with:
           action: terraform-init
+          github_secrets: ${{ steps.github-secrets.outputs.secrets }}
 
       - name: Test
         uses: suzuki-shunsuke/tfaction@5d2ecf0f4898a0b3ecc6b536e9a3f4691f46bfad # v2.0.0
@@ -141,3 +149,4 @@ jobs:
         with:
           action: plan
           github_token: ${{ steps.app-token.outputs.token }}
+          github_secrets: ${{ steps.github-secrets.outputs.secrets }}


### PR DESCRIPTION
- schedule-detect-drifts.yaml:
  - GitHub Secretsを出力するステップを追加し、Terraform InitおよびTestステップで使用するように変更。

- terraform-deploy.yaml:
  - GitHub Secretsを出力するステップを追加し、Terraform InitおよびApplyステップで使用するように変更。

- wc-terraform-pull-request.yaml:
  - GitHub Secretsを出力するステップを追加し、Terraform InitおよびTestステップで使用するように変更。