### PR TITLE
fix: GitHub Secretsのパラメータ名を修正

### DIFF
--- a/.github/workflows/schedule-detect-drifts.yaml
+++ b/.github/workflows/schedule-detect-drifts.yaml
@@ -104,7 +104,7 @@ jobs:
         uses: suzuki-shunsuke/tfaction@5d2ecf0f4898a0b3ecc6b536e9a3f4691f46bfad # v2.0.0
         with:
           action: terraform-init
-          github_secrets: ${{ steps.github-secrets.outputs.secrets }}
+          secrets: ${{ steps.github-secrets.outputs.secrets }}
 
       - name: Test
         uses: suzuki-shunsuke/tfaction@5d2ecf0f4898a0b3ecc6b536e9a3f4691f46bfad # v2.0.0
@@ -117,7 +117,7 @@ jobs:
         with:
           action: plan
           github_token: ${{ steps.app-token.outputs.token }}
-          github_secrets: ${{ steps.github-secrets.outputs.secrets }}
+          secrets: ${{ steps.github-secrets.outputs.secrets }}
 
       - name: Update Drift Issue
         uses: suzuki-shunsuke/tfaction@5d2ecf0f4898a0b3ecc6b536e9a3f4691f46bfad # v2.0.0

--- a/.github/workflows/terraform-deploy.yaml
+++ b/.github/workflows/terraform-deploy.yaml
@@ -119,14 +119,14 @@ jobs:
         uses: suzuki-shunsuke/tfaction@5d2ecf0f4898a0b3ecc6b536e9a3f4691f46bfad # v2.0.0
         with:
           action: terraform-init
-          github_secrets: ${{ steps.github-secrets.outputs.secrets }}
+          secrets: ${{ steps.github-secrets.outputs.secrets }}
 
       - name: Apply
         uses: suzuki-shunsuke/tfaction@5d2ecf0f4898a0b3ecc6b536e9a3f4691f46bfad # v2.0.0
         with:
           action: apply
           github_token: ${{ steps.app-token.outputs.token }}
-          github_secrets: ${{ steps.github-secrets.outputs.secrets }}
+          secrets: ${{ steps.github-secrets.outputs.secrets }}
 
       # Add this after apply
       - name: Update PR Branch

--- a/.github/workflows/wc-terraform-pull-request.yaml
+++ b/.github/workflows/wc-terraform-pull-request.yaml
@@ -136,7 +136,7 @@ jobs:
         uses: suzuki-shunsuke/tfaction@5d2ecf0f4898a0b3ecc6b536e9a3f4691f46bfad # v2.0.0
         with:
           action: terraform-init
-          github_secrets: ${{ steps.github-secrets.outputs.secrets }}
+          secrets: ${{ steps.github-secrets.outputs.secrets }}
 
       - name: Test
         uses: suzuki-shunsuke/tfaction@5d2ecf0f4898a0b3ecc6b536e9a3f4691f46bfad # v2.0.0
@@ -149,4 +149,4 @@ jobs:
         with:
           action: plan
           github_token: ${{ steps.app-token.outputs.token }}
-          github_secrets: ${{ steps.github-secrets.outputs.secrets }}
+          secrets: ${{ steps.github-secrets.outputs.secrets }}


### PR DESCRIPTION
- schedule-detect-drifts.yaml、terraform-deploy.yaml、wc-terraform-pull-request.yamlで、`github_secrets`を`secrets`に変更しました。